### PR TITLE
Implement Google Analytics

### DIFF
--- a/python/ecep/portal/context_processors.py
+++ b/python/ecep/portal/context_processors.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+def analytics(request):
+    return { 'ga_key': settings.GA_KEY }

--- a/python/ecep/portal/templates/about.html
+++ b/python/ecep/portal/templates/about.html
@@ -3,9 +3,6 @@
 {% block title %}Chicago Early Learning - About{% endblock %}
 
 {% block otherhead %}
-<script type="text/javascript">
-_gaq.push(['_trackPageview', '/about.html']);
-</script>
 {% endblock %}
 
 {% block content %}

--- a/python/ecep/portal/templates/base.html
+++ b/python/ecep/portal/templates/base.html
@@ -18,6 +18,7 @@
         <script type="text/javascript">
         var _gaq = _gaq || [];
         _gaq.push(['_setAccount', '{{ ga_key }}']);
+        _gaq.push(['_trackPageview', '{{ request.path }}']);
         </script>
         {% block otherhead %}{% endblock %}
     </head> 

--- a/python/ecep/portal/templates/compare.html
+++ b/python/ecep/portal/templates/compare.html
@@ -3,9 +3,6 @@
 {% block title %}Chicago Early Learning{% endblock %}
 
 {% block otherhead %}
-<script type="text/javascript">
-_gaq.push(['_trackPageview', '/compare/{{ location_a.item.id }}/{{ location_b.item.id }}/']);
-</script>
 {% endblock %}
 
 {% block content %}

--- a/python/ecep/portal/templates/faq.html
+++ b/python/ecep/portal/templates/faq.html
@@ -3,9 +3,6 @@
 {% block title %}Chicago Early Learning - FAQ{% endblock %}
 
 {% block otherhead %}
-<script type="text/javascript">
-_gaq.push(['_trackPageview', '/faq.html']);
-</script>
 {% endblock %}
 
 {% block content %}

--- a/python/ecep/portal/templates/index.html
+++ b/python/ecep/portal/templates/index.html
@@ -4,9 +4,6 @@
 {% block title %}Chicago Early Learning{% endblock %}
 
 {% block otherhead %}
-<script type="text/javascript">
-_gaq.push(['_trackPageview', '/']);
-</script>
 {% endblock %}
 
 {% block content %}

--- a/python/ecep/portal/templates/location.html
+++ b/python/ecep/portal/templates/location.html
@@ -5,9 +5,6 @@
 {% block title %}Chicago Early Learning{% endblock %}
 
 {% block otherhead %}
-<script type="text/javascript">
-_gaq.push(['_trackPageview', '/location/{{ item.id }}']);
-</script>
 {% endblock %}
 
 {% block content %}

--- a/python/ecep/portal/views.py
+++ b/python/ecep/portal/views.py
@@ -1,4 +1,4 @@
-from django.template import Context, loader
+from django.template import RequestContext
 from django.shortcuts import render_to_response, get_object_or_404
 from django.views.decorators.cache import cache_control
 from django.db.models import Q
@@ -12,7 +12,12 @@ logger = logging.getLogger(__name__)
 
 def index(request):
     fields = Location.get_boolean_fields()
-    return render_to_response('index.html', { 'fields':fields, 'ga_key':settings.GA_KEY })
+
+    ctx = RequestContext(request, {
+        'fields':fields
+    })
+
+    return render_to_response('index.html', context_instance=ctx)
 
 def location_details(location_id):
     """
@@ -61,17 +66,15 @@ def location(request, location_id):
         elif request.GET['m'] == 'popup':
             tpl = 'popup.html'
 
-    # Attach GA key only if this is a bona fide page
-    if tpl == 'location.html':
-        context.update(ga_key=settings.GA_KEY)
-
     context.update(is_popup=(tpl == 'popup.html'))
     context.update(is_embed=(tpl == 'embed.html'))
 
-    return render_to_response(tpl, context)
+    context = RequestContext(request, context)
+
+    return render_to_response(tpl, context_instance=context)
 
 
-@cache_control(must_revalidate=False, max_age=30)
+@cache_control(must_revalidate=False, max_age=3600)
 def location_list(request):
     """
     Get a list of all the locations.
@@ -123,20 +126,18 @@ def compare(request, a, b):
     if 'm' in request.GET and request.GET['m'] == 'embed':
         tpl = 'compare_content.html'
 
-    context = { 'location_a': loc_a, 'location_b': loc_b }
+    ctx = RequestContext(request, { 
+        'location_a': loc_a, 'location_b': loc_b 
+        })
 
-    # Attach GA key only if this is a bona fide page
-    if tpl == 'compare.html':
-        context.update(ga_key=settings.GA_KEY)
-
-    return render_to_response(tpl, context)
+    return render_to_response(tpl, context_instance=ctx)
 
 
 def about(request):
-    return render_to_response('about.html', { 'ga_key': settings.GA_KEY })
+    return render_to_response('about.html', context_instance=RequestContext(request))
 
 
 def faq(request):
-    return render_to_response('faq.html', { 'ga_key': settings.GA_KEY })
+    return render_to_response('faq.html', context_instance=RequestContext(request))
 
 

--- a/python/ecep/settings.py
+++ b/python/ecep/settings.py
@@ -93,6 +93,17 @@ TEMPLATE_LOADERS = (
 #     'django.template.loaders.eggs.Loader',
 )
 
+TEMPLATE_CONTEXT_PROCESSORS = {
+    'django.contrib.auth.context_processors.auth',
+    'django.core.context_processors.debug',
+    'django.core.context_processors.i18n',
+    'django.core.context_processors.media',
+    'django.core.context_processors.static',
+    'django.core.context_processors.request',
+    'django.contrib.messages.context_processors.messages',
+    'portal.context_processors.analytics',
+}
+
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
Tested with Google Analytics key for local development. GA will now track all page views and many mapping events, such as geocoding and filtering.

The default GA key is one used in development, and when deploying to production, we will have to set the GA_KEY is local_settings.py to the real value.
