### PR TITLE
Improve compare-box popup behavior & instructions.

### DIFF
--- a/python/ecep/portal/static/css/ecep.css
+++ b/python/ecep/portal/static/css/ecep.css
@@ -227,6 +227,9 @@ h2.question {
 #compare-box {
     display:none;
 }
+.cmp-popover {
+    z-index: 2080;
+}
 
 .container .location {
     width: 50%;


### PR DESCRIPTION
- When two items are selectable, they are highlighted.
- When any new item is added, it is placed at the bottom of the list.
- When there are not two items selected, the compare button becomes disabled,
  and a popover attached that requests only two items at a time.
