### PR TITLE
Fix ordering of playbooks

### DIFF
--- a/deployment/playbooks/all.yml
+++ b/deployment/playbooks/all.yml
@@ -2,5 +2,5 @@
  - include: base.yml
  - include: database.yml
  - include: server.yml
- - include: rabbitmq.yml
  - include: django.yml
+ - include: rabbitmq.yml


### PR DESCRIPTION
Messed up the ordering of the playbook - celery can't start till Django is set up.
