### PR TITLE
Install npm for all deployments

### DIFF
--- a/deployment/playbooks/base.yml
+++ b/deployment/playbooks/base.yml
@@ -36,7 +36,6 @@
   - name: Install node packages
     command: npm install ${item} -g
     with_items: ${node_packages}
-    only_if: ${django_jenkins}
 
   - name: Set ownership of directories
     file: path=${item} state=directory owner=${ansible_ssh_user}


### PR DESCRIPTION
npm topojson package is a dependency for the export_topojson manage.py command so we need to install it with all deployment types.
