### PR TITLE
Need portal.sms for celery to work

### DIFF
--- a/python/ecep/settings.py
+++ b/python/ecep/settings.py
@@ -117,10 +117,10 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    # Uncomment the next line to enable the admin:
     'django.contrib.admin',
     'django.contrib.gis',
     'portal',
+    'portal.sms',           # This is necessary for the celery worker to respond to messages
     'django_twilio',
     'gunicorn',
     'faq',


### PR DESCRIPTION
This is why sms wasn't working on the staging server.  It really is required.
