### PR TITLE
Bump django-celery version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ geopy==0.95.1
 django-twilio==0.2
 twilio==3.5.1
 django-rosetta==0.6.8
-django-celery==3.0.17
+django-celery==3.0.21
 librabbitmq==1.0.1
 psycopg2==2.5.1
 gunicorn==17.5


### PR DESCRIPTION
For whatever reason ansible was having problems installing the old
version on a fresh box, something to do with pytz.  This fixes it.
