### PR TITLE
Check for 'None' string in accredited value when creating tooltip text

### DIFF
--- a/python/ecep/portal/models.py
+++ b/python/ecep/portal/models.py
@@ -221,7 +221,7 @@ class Location(models.Model):
                       'share': _('Share')}
 
         # More information for tooltip icon
-        accreditation = ['Accredited'] if self.accred else []
+        accreditation = ['Accredited'] if self.accred != 'None' else []
         accreditation.append('School' if self.is_cps_based else 'Center')
         
         # Tooltips - necessary for translations in handlebars template


### PR DESCRIPTION
'None' is actually a string in the data, not the python value of
None so this if statement was always returning true. Now
we explicitly check for the 'None' string.

I don't really like the idea of having a value that represents 'None'
that isn't null or empty so we may want to rethink how data is being
loaded and checks being performed, but there really isnt a point in
doing that until we have the actual data in case it changes.
