### PR TITLE
Move logic to set top margin for list view into browse.js

### DIFF
--- a/python/ecep/portal/static/js/cel/pages/browse.js
+++ b/python/ecep/portal/static/js/cel/pages/browse.js
@@ -151,7 +151,9 @@ define(['jquery', 'Leaflet', 'Handlebars', 'text!templates/neighborhoodList.html
                 html = (isNb ? neighborhoodList : locationList),
                 dataList,
                 template = Handlebars.compile(html),
-                handlebarsData = [];
+                handlebarsData = [],
+                th = $("#filter-options").height();
+
 
             // Sort everything by name ascending
             dataList = $.map(data, function(v, k) {
@@ -171,6 +173,9 @@ define(['jquery', 'Leaflet', 'Handlebars', 'text!templates/neighborhoodList.html
 
             $locationWrapper.empty();
             $locationWrapper.append(template(handlebarsData));
+
+            // Set top margin so that list is not hidden by filters
+            $locationWrapper.css("top", th);
 
             // set header title
             var $headerFav = $('#header-fav'),

--- a/python/ecep/portal/static/js/lib/styling.js
+++ b/python/ecep/portal/static/js/lib/styling.js
@@ -8,10 +8,8 @@
 
 define(['./slidepanel'], function($) {
     $(document).ready(function(){
+        var th;
 
-        var th = $("#filter-options").height();
-        $(".locations-wrapper").css("top", th);
-        
         $(window).on("resize", function(){
             th = $("#filter-options").height();
             $(".locations-wrapper").css("top", th);


### PR DESCRIPTION
This fixes the problem where the results list was sometimes
being hidden by the filters. The problem seemed to be from
javascript functions/events being fired at random times.
This fixes the problem by calling this function only during
the actual construction of list results when we know the
filter div is already populated.
