### PR TITLE
Update QRIS ratings to display Coming Soon only on null/empty db field

### DIFF
--- a/python/ecep/portal/admin.py
+++ b/python/ecep/portal/admin.py
@@ -41,10 +41,11 @@ class LocationForm(forms.ModelForm):
     geom = forms.CharField(label="Geocoded Point", widget=MapWidget())
     q_rating = forms.ChoiceField(label=_('Quality Rating'),
                                  choices=(('', _('Select a rating')),
-                                          ('licensed', _('Licensed')),
-                                          ('bronze', _('Bronze')),
-                                          ('silver', _('Silver')),
-                                          ('gold', _('Gold'))),
+                                          ('None', _('None')),
+                                          ('Licensed', _('Licensed')),
+                                          ('Bronze', _('Bronze')),
+                                          ('Silver', _('Silver')),
+                                          ('Gold', _('Gold'))),
                                  required=False)
     site_name = forms.CharField(widget=forms.TextInput(attrs={'size':'50'}))
 

--- a/python/ecep/portal/models.py
+++ b/python/ecep/portal/models.py
@@ -101,7 +101,7 @@ class Location(models.Model):
     display_include = {'ages', 'accred', 'accept_ccap', 'is_home_visiting', 'is_hs', 'is_ehs',
                        'is_community_based', 'is_cps_based'}
 
-    q_rating_translations = [_('Licensed'), _('Bronze'), _('Silver'), _('Gold')]
+    q_rating_translations = [_('None'), _('Licensed'), _('Bronze'), _('Silver'), _('Gold')]
 
     def __unicode__(self):
         return unicode(self.site_name)
@@ -236,8 +236,13 @@ class Location(models.Model):
                         'value': ', '.join(week_values) if week_values else _('None')})
 
         # Quality Rating
-        q_rating = self.q_rating or 'None'
-        item['quality'] = q_rating.lower()
+        # default empty db entry to coming soon so we don't have to modify code when CEL chooses 
+        #   to implement this. No q_rating is explicitly set as 'None' in the database and will 
+        #   be properly displayed in the UI as long as the db field is set to 'None'    
+        # key for displayed image, not to be translated
+        item['quality'] = self.q_rating.lower() or 'none'
+        # translatable displayed text
+        q_rating = self.q_rating or 'Coming Soon'
         sfields.append({'fieldname': _('Quality Rating'), 'value': _(q_rating)})
 
         # Phone
@@ -258,8 +263,7 @@ class Location(models.Model):
         # This way we can do this with django and not have to worry about making a separate
         # handlebars helper
         trans_dict = {'more': _('More'), 'website': _('Website'), 'directions': _('Directions'),
-                      'share': _('Share'), 'qrisrating': _('QRIS Rating'),
-                      'comingsoon': _('Coming Soon')}
+                      'share': _('Share'), 'qrisrating': _('QRIS Rating')}
 
         # More information for tooltip icon
         accreditation = ['Accredited'] if self.accred != 'None' else []
@@ -268,7 +272,7 @@ class Location(models.Model):
         # Tooltips - necessary for translations in handlebars template
         tooltip = {'directions': _('Directions from Google'), 'moreinfo': _('Click to show more information'),
                    'star': _('Click to save to your list'), 'accreditation': ' '.join(accreditation),
-                   'quality': q_rating}
+                   'quality': _(q_rating)}
 
         return {'item': item, 'phone': phone, 'sfields': sfields,
                 'bfields': {'fieldname': _('Other Features'), 'values': bfields},

--- a/python/ecep/portal/static/js/cel/templates/locationList.html
+++ b/python/ecep/portal/static/js/cel/templates/locationList.html
@@ -12,8 +12,7 @@
         <h2 class="truncate">{{item.address}}, {{item.city}}, {{item.state}} {{item.zip}}</h2>
       </a>
       <a href="#" id="quality-icon" class="hideonmobile directions-icon hint--right"
-          data-hint="{{ translations.qrisrating }}: {{ translations.comingsoon }}">
-          <!-- data-hint="{{ translations.qrisrating }}: {{ tooltip.quality }}"> -->
+          data-hint="{{ translations.qrisrating }}: {{ tooltip.quality }}">
           <img data-img="quality-{{ item.quality }}" class="quality-icon" src='{{static "img/icons/quality-none.png"}}' />
       </a>
       <a href="#" id="loc-icon" class="hideonmobile directions-icon hint--right"


### PR DESCRIPTION
If QRIS Rating of 'None' is desired, it must be set explicitly. An dropdown entry on the admin page was added for this. Setting a qris entry in the database to null or the empty string will display 'Coming Soon' on the page. Other ratings are unaffected.
